### PR TITLE
Multiple Categories

### DIFF
--- a/src/main/kotlin/data/file/FileCreator.kt
+++ b/src/main/kotlin/data/file/FileCreator.kt
@@ -3,49 +3,89 @@ package data.file
 import data.repository.SettingsRepository
 import data.repository.SourceRootRepository
 import model.AndroidComponent
+import model.Category
 import model.FileType
 import model.Settings
 
 private const val LAYOUT_DIRECTORY = "layout"
 
 interface FileCreator {
-
-    fun createScreenFiles(packageName: String, screenName: String, androidComponent: AndroidComponent, module: String)
+    fun createScreenFiles(category: Category, packageName: String, screenName: String, androidComponent: AndroidComponent, module: String)
 }
 
-class FileCreatorImpl(private val settingsRepository: SettingsRepository,
-                      private val sourceRootRepository: SourceRootRepository) : FileCreator {
+class FileCreatorImpl(
+        private val settingsRepository: SettingsRepository,
+        private val sourceRootRepository: SourceRootRepository
+) : FileCreator {
 
-    override fun createScreenFiles(packageName: String, screenName: String, androidComponent: AndroidComponent, module: String) {
+    override fun createScreenFiles(
+            category: Category,
+            packageName: String,
+            screenName: String,
+            androidComponent: AndroidComponent,
+            module: String
+    ) {
         val codeSubdirectory = findCodeSubdirectory(packageName, module)
         val resourcesSubdirectory = findResourcesSubdirectory(module)
         if (codeSubdirectory != null) {
             settingsRepository.loadSettings().apply {
                 val baseClass = getAndroidComponentBaseClass(androidComponent)
-                screenElements.forEach {
+                category.screenElements.forEach {
                     if (it.fileType == FileType.LAYOUT_XML) {
-                        val file = File(it.fileName(screenName, packageName, androidComponent.displayName, baseClass), it.body(screenName, packageName, androidComponent.displayName, baseClass), it.fileType)
+                        val file = File(
+                                it.fileName(screenName, packageName, androidComponent.displayName, baseClass),
+                                it.body(screenName, packageName, androidComponent.displayName, baseClass),
+                                it.fileType
+                        )
                         resourcesSubdirectory.addFile(file)
                     } else {
-                        val file = File(it.fileName(screenName, packageName, androidComponent.displayName, baseClass), it.body(screenName, packageName, androidComponent.displayName, baseClass), it.fileType)
-                        codeSubdirectory.addFile(file)
+                        val body = it.body(screenName, packageName, androidComponent.displayName, baseClass)
+                        val packageLine = body.lines()[0]
+                        val packageNameFromTemplate = packageLine.split(" ")[1]
+                        if (packageNameFromTemplate == packageName) {
+                            val file = File(
+                                    it.fileName(screenName, packageName, androidComponent.displayName, baseClass),
+                                    it.body(screenName, packageName, androidComponent.displayName, baseClass),
+                                    it.fileType
+                            )
+                            codeSubdirectory.addFile(file)
+                        } else {
+                            val innerCodeSubDirectory = findCodeSubdirectory(packageNameFromTemplate, module)
+                            innerCodeSubDirectory?.let { directory ->
+                                val file = File(
+                                        it.fileName(screenName, packageName, androidComponent.displayName, baseClass),
+                                        it.body(screenName, packageName, androidComponent.displayName, baseClass),
+                                        it.fileType
+                                )
+                                directory.addFile(file)
+                            } ?: kotlin.run {
+                                val file = File(
+                                        it.fileName(screenName, packageName, androidComponent.displayName, baseClass),
+                                        it.body(screenName, packageName, androidComponent.displayName, baseClass),
+                                        it.fileType
+                                )
+                                codeSubdirectory.addFile(file)
+                            }
+                        }
                     }
                 }
             }
         }
     }
 
-    private fun findCodeSubdirectory(packageName: String, module: String): Directory? = sourceRootRepository.findCodeSourceRoot(module)?.run {
-        var subdirectory = directory
-        packageName.split(".").forEach {
-            subdirectory = subdirectory.findSubdirectory(it) ?: subdirectory.createSubdirectory(it)
-        }
-        return subdirectory
-    }
+    private fun findCodeSubdirectory(packageName: String, module: String): Directory? =
+            sourceRootRepository.findCodeSourceRoot(module)?.run {
+                var subdirectory = directory
+                packageName.split(".").forEach {
+                    subdirectory = subdirectory.findSubdirectory(it) ?: subdirectory.createSubdirectory(it)
+                }
+                return subdirectory
+            }
 
-    private fun findResourcesSubdirectory(module: String) = sourceRootRepository.findResourcesSourceRoot(module).directory.run {
-        findSubdirectory(LAYOUT_DIRECTORY) ?: createSubdirectory(LAYOUT_DIRECTORY)
-    }
+    private fun findResourcesSubdirectory(module: String) =
+            sourceRootRepository.findResourcesSourceRoot(module).directory.run {
+                findSubdirectory(LAYOUT_DIRECTORY) ?: createSubdirectory(LAYOUT_DIRECTORY)
+            }
 
     private fun Settings.getAndroidComponentBaseClass(androidComponent: AndroidComponent) = when (androidComponent) {
         AndroidComponent.ACTIVITY -> activityBaseClass

--- a/src/main/kotlin/model/Category.kt
+++ b/src/main/kotlin/model/Category.kt
@@ -1,0 +1,19 @@
+package model
+
+import java.io.Serializable
+import java.util.*
+
+private const val UNNAMED_CATEGORY = "UnnamedCategory"
+
+data class Category(
+    var id: Int,
+    var name: String = "",
+    var screenElements: MutableList<ScreenElement>
+) : Serializable {
+
+    override fun toString() = name
+
+    companion object {
+        fun getDefault() = Category(Random().nextInt(), UNNAMED_CATEGORY, defaultScreenElements())
+    }
+}

--- a/src/main/kotlin/model/Settings.kt
+++ b/src/main/kotlin/model/Settings.kt
@@ -4,16 +4,26 @@ import java.io.Serializable
 
 private const val DEFAULT_BASE_ACTIVITY_CLASS = "androidx.appcompat.app.AppCompatActivity"
 private const val DEFAULT_BASE_FRAGMENT_CLASS = "androidx.fragment.app.Fragment"
-private val DEFAULT_MVP_TEMPLATE = "package ${Variable.PACKAGE_NAME.value}\n\nimport ${Variable.ANDROID_COMPONENT_FULL_CLASS_NAME.value}\n\nclass ${Variable.NAME.value}${Variable.ANDROID_COMPONENT_NAME.value} : ${Variable.ANDROID_COMPONENT_CLASS_NAME.value}"
+private val DEFAULT_MVP_TEMPLATE =
+        "package ${Variable.PACKAGE_NAME.value}\n\nimport ${Variable.ANDROID_COMPONENT_FULL_CLASS_NAME.value}\n\nclass ${Variable.NAME.value}${Variable.ANDROID_COMPONENT_NAME.value} : ${Variable.ANDROID_COMPONENT_CLASS_NAME.value}"
 private val DEFAULT_VIEW_TEMPLATE = "package ${Variable.PACKAGE_NAME.value}\n\ninterface ${Variable.NAME.value}${Variable.SCREEN_ELEMENT.value}"
 
-private fun defaultScreenElements() = mutableListOf(
+public fun defaultScreenElements() = mutableListOf(
         ScreenElement("MVP", DEFAULT_MVP_TEMPLATE, FileType.KOTLIN, "${Variable.NAME.value}${Variable.ANDROID_COMPONENT_NAME.value}"),
         ScreenElement("Presenter", FileType.KOTLIN.defaultTemplate, FileType.KOTLIN, FileType.KOTLIN.defaultFileName),
         ScreenElement("View", DEFAULT_VIEW_TEMPLATE, FileType.KOTLIN, FileType.KOTLIN.defaultFileName),
         ScreenElement("layout", FileType.LAYOUT_XML.defaultTemplate, FileType.LAYOUT_XML, FileType.LAYOUT_XML.defaultFileName)
 )
 
-data class Settings(var screenElements: MutableList<ScreenElement> = defaultScreenElements(),
-               var activityBaseClass: String = DEFAULT_BASE_ACTIVITY_CLASS,
-               var fragmentBaseClass: String = DEFAULT_BASE_FRAGMENT_CLASS) : Serializable
+private fun defaultCategories() = mutableListOf(
+        Category(1, "Activity", defaultScreenElements()),
+        Category(2, "Fragment", defaultScreenElements()),
+        Category(3, "Adapter", defaultScreenElements())
+)
+
+data class Settings(
+        var categories: MutableList<Category> = defaultCategories(),
+        var currentlySelectedCategory: Category = categories[0],
+        var activityBaseClass: String = DEFAULT_BASE_ACTIVITY_CLASS,
+        var fragmentBaseClass: String = DEFAULT_BASE_FRAGMENT_CLASS
+) : Serializable

--- a/src/main/kotlin/ui/newscreen/NewScreenDialog.kt
+++ b/src/main/kotlin/ui/newscreen/NewScreenDialog.kt
@@ -7,6 +7,8 @@ import data.repository.ModuleRepositoryImpl
 import data.repository.SettingsRepositoryImpl
 import data.repository.SourceRootRepositoryImpl
 import model.AndroidComponent
+import model.Category
+import model.Settings
 import javax.swing.JComponent
 
 class NewScreenDialog(project: Project, currentPath: CurrentPath?) : DialogWrapper(true), NewScreenView {
@@ -18,20 +20,23 @@ class NewScreenDialog(project: Project, currentPath: CurrentPath?) : DialogWrapp
     init {
         val projectStructure = ProjectStructureImpl(project)
         val sourceRootRepository = SourceRootRepositoryImpl(projectStructure)
+        val settingsImpl = SettingsRepositoryImpl(project)
         val fileCreator = FileCreatorImpl(SettingsRepositoryImpl(project), sourceRootRepository)
         val packageExtractor = PackageExtractorImpl(currentPath, sourceRootRepository)
         val writeActionDispatcher = WriteActionDispatcherImpl()
         val moduleRepository = ModuleRepositoryImpl(projectStructure)
-        presenter = NewScreenPresenter(this, fileCreator, packageExtractor, writeActionDispatcher, moduleRepository, currentPath)
+        presenter = NewScreenPresenter(this, settingsImpl, fileCreator, packageExtractor, writeActionDispatcher, moduleRepository, currentPath)
         init()
     }
 
     override fun doOKAction() =
             presenter.onOkClick(
+                    panel.categoryComboBox.selectedItem as Category,
                     panel.packageTextField.text,
                     panel.nameTextField.text,
                     AndroidComponent.values()[panel.androidComponentComboBox.selectedIndex],
-                    panel.moduleComboBox.selectedItem as String)
+                    panel.moduleComboBox.selectedItem as String
+            )
 
     override fun createCenterPanel(): JComponent {
         presenter.onLoadView()
@@ -42,6 +47,12 @@ class NewScreenDialog(project: Project, currentPath: CurrentPath?) : DialogWrapp
 
     override fun showPackage(packageName: String) {
         panel.packageTextField.text = packageName
+    }
+
+    override fun showCategories(categories: List<Category>) = categories.forEach { panel.categoryComboBox.addItem(it) }
+
+    override fun selectCategory(category: Category) {
+        panel.categoryComboBox.selectedItem = category
     }
 
     override fun showModules(modules: List<String>) = modules.forEach { panel.moduleComboBox.addItem(it) }

--- a/src/main/kotlin/ui/newscreen/NewScreenPanel.kt
+++ b/src/main/kotlin/ui/newscreen/NewScreenPanel.kt
@@ -2,6 +2,7 @@ package ui.newscreen
 
 import com.intellij.openapi.ui.ComboBox
 import model.AndroidComponent
+import model.Category
 import java.awt.Dimension
 import java.awt.GridLayout
 import javax.swing.JLabel
@@ -14,11 +15,14 @@ class NewScreenPanel : JPanel() {
     val nameTextField = JTextField()
     val packageTextField = JTextField()
 
+    val categoryComboBox = ComboBox<Category>()
     val androidComponentComboBox = ComboBox<AndroidComponent>(AndroidComponent.values())
     val moduleComboBox = ComboBox<String>()
 
     init {
         layout = GridLayout(0, 2)
+        add(JLabel("Category:"))
+        add(categoryComboBox)
         add(JLabel("Module:"))
         add(moduleComboBox)
         add(JLabel("Package:"))

--- a/src/main/kotlin/ui/newscreen/NewScreenPresenter.kt
+++ b/src/main/kotlin/ui/newscreen/NewScreenPresenter.kt
@@ -5,24 +5,30 @@ import data.file.FileCreator
 import data.file.PackageExtractor
 import data.file.WriteActionDispatcher
 import data.repository.ModuleRepository
+import data.repository.SettingsRepositoryImpl
 import model.AndroidComponent
+import model.Category
 
-class NewScreenPresenter(private val view: NewScreenView,
-                         private val fileCreator: FileCreator,
-                         private val packageExtractor: PackageExtractor,
-                         private val writeActionDispatcher: WriteActionDispatcher,
-                         private val moduleRepository: ModuleRepository,
-                         private val currentPath: CurrentPath?) {
+class NewScreenPresenter(
+        private val view: NewScreenView,
+        private val settings: SettingsRepositoryImpl,
+        private val fileCreator: FileCreator,
+        private val packageExtractor: PackageExtractor,
+        private val writeActionDispatcher: WriteActionDispatcher,
+        private val moduleRepository: ModuleRepository,
+        private val currentPath: CurrentPath?
+) {
 
     fun onLoadView() {
+        view.showCategories(settings.loadSettings().categories)
         view.showPackage(packageExtractor.extractFromCurrentPath())
         view.showModules(moduleRepository.getAllModules())
         currentPath?.let { view.selectModule(currentPath.module) }
     }
 
-    fun onOkClick(packageName: String, screenName: String, androidComponent: AndroidComponent, module: String) {
+    fun onOkClick(category: Category, packageName: String, screenName: String, androidComponent: AndroidComponent, module: String) {
         writeActionDispatcher.dispatch {
-            fileCreator.createScreenFiles(packageName, screenName, androidComponent, module)
+            fileCreator.createScreenFiles(category, packageName, screenName, androidComponent, module)
         }
         view.close()
     }

--- a/src/main/kotlin/ui/newscreen/NewScreenView.kt
+++ b/src/main/kotlin/ui/newscreen/NewScreenView.kt
@@ -1,8 +1,12 @@
 package ui.newscreen
 
+import model.Category
+
 interface NewScreenView {
 
     fun close()
+    fun showCategories(categories: List<Category>)
+    fun selectCategory(category: Category)
     fun showPackage(packageName: String)
     fun showModules(modules: List<String>)
     fun selectModule(module: String)

--- a/src/main/kotlin/ui/settings/SettingsPanel.kt
+++ b/src/main/kotlin/ui/settings/SettingsPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.IdeBorderFactory
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
+import model.Category
 import model.FileType
 import model.ScreenElement
 import java.awt.*
@@ -14,16 +15,24 @@ import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JTextField
 import javax.swing.ListSelectionModel
+import javax.swing.SwingConstants.RIGHT
 
 class SettingsPanel(project: Project) : JPanel() {
 
-    val nameTextField = JTextField()
+    val categoryNameTextField = JTextField()
+    val screenElementNameTextField = JTextField()
+
+    val categoriesListModel = CollectionListModel<Category>()
+    val categoriesList = JBList<Category>(categoriesListModel).apply {
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+    }
+    val categoryToolbarDecorator: ToolbarDecorator = ToolbarDecorator.createDecorator(categoriesList)
 
     val screenElementsListModel = CollectionListModel<ScreenElement>()
     val screenElementsList = JBList<ScreenElement>(screenElementsListModel).apply {
         selectionMode = ListSelectionModel.SINGLE_SELECTION
     }
-    val toolbarDecorator: ToolbarDecorator = ToolbarDecorator.createDecorator(screenElementsList)
+    val screenElementToolbarDecorator: ToolbarDecorator = ToolbarDecorator.createDecorator(screenElementsList)
 
     val activityTextField = JTextField()
     val fragmentTextField = JTextField()
@@ -49,15 +58,30 @@ class SettingsPanel(project: Project) : JPanel() {
         screenElementDetailsPanel = createScreenElementDetailsPanel()
 
         val rightPanel = createSplitterRightPanel(androidComponentsPanel, screenElementDetailsPanel)
-
-        addSplitter(screenElementsPanel, rightPanel)
+        add(createVerticalSplitter(createCategoriesPanel(), createSplitter(screenElementsPanel, rightPanel)), BorderLayout.PAGE_START)
         addCodePanel(onHelpClick)
+    }
+
+    private fun createCategoriesPanel() = JPanel().apply {
+        border = IdeBorderFactory.createTitledBorder("Categories", false)
+        layout = GridLayout(0, 1)
+        val categoryLabel = JLabel("Category Name: ")
+        categoryLabel.horizontalAlignment = RIGHT
+        val categoryNameSplitter = JBSplitter(0.5f).apply {
+            firstComponent = categoryLabel
+            secondComponent = categoryNameTextField
+        }
+        val categorySplitter = JBSplitter(0.3f).apply {
+            firstComponent = categoryToolbarDecorator.createPanel()
+            secondComponent = categoryNameSplitter
+        }
+        add(categorySplitter)
     }
 
     private fun createScreenElementsPanel() = JPanel().apply {
         border = IdeBorderFactory.createTitledBorder("Screen Elements", false)
         layout = GridLayout(1, 1)
-        add(toolbarDecorator.createPanel())
+        add(screenElementToolbarDecorator.createPanel())
     }
 
     private fun createAndroidComponentsPanel() = JPanel().apply {
@@ -73,7 +97,7 @@ class SettingsPanel(project: Project) : JPanel() {
         border = IdeBorderFactory.createTitledBorder("Screen Element Details", false)
         layout = GridBagLayout()
         add(screenElementNameLabel, constraintsLeft(0, 0))
-        add(nameTextField, constraintsRight(1, 0))
+        add(screenElementNameTextField, constraintsRight(1, 0))
         add(fileNameLabel, constraintsLeft(0, 1))
         add(fileNameTextField, constraintsRight(1, 1))
         add(fileTypeLabel, constraintsLeft(0, 2))
@@ -106,12 +130,17 @@ class SettingsPanel(project: Project) : JPanel() {
         fill = GridBagConstraints.HORIZONTAL
     }
 
-    private fun addSplitter(leftPanel: JPanel, rightPanel: JPanel) {
-        add(JBSplitter(0.2f).apply {
-            firstComponent = leftPanel
-            secondComponent = rightPanel
-        }, BorderLayout.PAGE_START)
-    }
+    private fun createVerticalSplitter(leftPanel: JPanel, rightPanel: JPanel): JPanel =
+            JBSplitter(true, 0.4f).apply {
+                firstComponent = leftPanel
+                secondComponent = rightPanel
+            }
+
+    private fun createSplitter(leftPanel: JPanel, rightPanel: JPanel): JPanel =
+            JBSplitter(0.2f).apply {
+                firstComponent = leftPanel
+                secondComponent = rightPanel
+            }
 
     private fun createSplitterRightPanel(androidComponentsPanel: JPanel, screenElementDetailsPanel: JPanel) =
             JPanel(GridLayout(0, 1)).apply {
@@ -126,7 +155,7 @@ class SettingsPanel(project: Project) : JPanel() {
 
     fun setScreenElementDetailsEnabled(isEnabled: Boolean) {
         screenElementDetailsPanel.isEnabled = isEnabled
-        nameTextField.isEnabled = isEnabled
+        screenElementNameTextField.isEnabled = isEnabled
         fileNameTextField.isEnabled = isEnabled
         fileTypeComboBox.isEnabled = isEnabled
         screenElementNameLabel.isEnabled = isEnabled

--- a/src/main/kotlin/ui/settings/SettingsView.kt
+++ b/src/main/kotlin/ui/settings/SettingsView.kt
@@ -1,19 +1,30 @@
 package ui.settings
 
+import model.Category
 import model.FileType
 import model.ScreenElement
 
 interface SettingsView {
     fun setUpListeners()
+
+    fun addCategory(category: Category)
+    fun selectCategory(index: Int)
+    fun updateCategory(index: Int, category: Category)
+    fun removeCategory(index: Int)
+    fun showCategories(categories: List<Category>)
+    fun clearCategories()
+    fun showCategoryName(name: String)
+
     fun addScreenElement(screenElement: ScreenElement)
     fun selectScreenElement(index: Int)
-    fun showName(name: String)
-    fun addTextChangeListeners()
-    fun removeTextChangeListeners()
     fun updateScreenElement(index: Int, screenElement: ScreenElement)
     fun removeScreenElement(index: Int)
     fun showScreenElements(screenElements: List<ScreenElement>)
     fun clearScreenElements()
+    fun showScreenElementName(name: String)
+
+    fun addTextChangeListeners()
+    fun removeTextChangeListeners()
     fun showSampleCode(text: String)
     fun showTemplate(template: String)
     fun showActivityBaseClass(text: String)


### PR DESCRIPTION
Changes Made:

1. Option to create multiple categories, where each category can contain multiple ScreenElements with their own templates. The new screen dialog will contain another dropdown to select the Category, and files for that category would be created
2. If a file template package has a path which is different than the original package, then the other directories would also be created and the corresponding files would be put in those specific directories accordingly


Known Issues: 
- Even on clicking Cancel the settings are being persisted.