### PR TITLE
Enable Undo/Redo

### DIFF
--- a/src/main/kotlin/data/file/WriteActionDispatcher.kt
+++ b/src/main/kotlin/data/file/WriteActionDispatcher.kt
@@ -1,14 +1,18 @@
 package data.file
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+
+private const val COMMAND_NAME = "Screen Generator"
+private const val GROUP_ID = "SCREEN_GENERATOR_ID"
 
 interface WriteActionDispatcher {
     fun dispatch(action: () -> Unit)
 }
 
-class WriteActionDispatcherImpl : WriteActionDispatcher {
+class WriteActionDispatcherImpl(val project: Project) : WriteActionDispatcher {
 
-    override fun dispatch(action: () -> Unit) = ApplicationManager.getApplication().runWriteAction {
+    override fun dispatch(action: () -> Unit) = WriteCommandAction.runWriteCommandAction(project, COMMAND_NAME, GROUP_ID, {
         action()
-    }
+    }, arrayOf())
 }

--- a/src/main/kotlin/ui/newscreen/NewScreenDialog.kt
+++ b/src/main/kotlin/ui/newscreen/NewScreenDialog.kt
@@ -20,7 +20,7 @@ class NewScreenDialog(project: Project, currentPath: CurrentPath?) : DialogWrapp
         val sourceRootRepository = SourceRootRepositoryImpl(projectStructure)
         val fileCreator = FileCreatorImpl(SettingsRepositoryImpl(project), sourceRootRepository)
         val packageExtractor = PackageExtractorImpl(currentPath, sourceRootRepository)
-        val writeActionDispatcher = WriteActionDispatcherImpl()
+        val writeActionDispatcher = WriteActionDispatcherImpl(project)
         val moduleRepository = ModuleRepositoryImpl(projectStructure)
         presenter = NewScreenPresenter(this, fileCreator, packageExtractor, writeActionDispatcher, moduleRepository, currentPath)
         init()


### PR DESCRIPTION
### Summary
Currently, we can't undo/redo our action after we generate a new screen. This could become a hassle when we have a lot of files to scroll through and delete it one by one. This will allow us undo/redo our screen generation.

### Github Issues:
[Cant Undo/Redo](https://github.com/gmatyszczak/screen-generator-plugin/issues/9)